### PR TITLE
Remove nested anchor

### DIFF
--- a/src/__tests__/toc.js
+++ b/src/__tests__/toc.js
@@ -236,6 +236,7 @@ and next element in the same inline token`
     mdIt(
       `@[toc]
 # [test](http://google.com)
+## text [test](http://google.com)
 ## **text**
 ## *text*
 ## ~~text~~
@@ -245,6 +246,7 @@ and next element in the same inline token`
     `<p><ul class="markdownIt-TOC">
 <li><a href="#test">test</a>
 <ul>
+<li><a href="#text%20test">text test</a></li>
 <li><a href="#text"><strong>text</strong></a></li>
 <li><a href="#text-2"><em>text</em></a></li>
 <li><a href="#text-3"><s>text</s></a></li>
@@ -253,6 +255,7 @@ and next element in the same inline token`
 </ul>
 </p>
 <h1 id="test"><a href="http://google.com">test</a></h1>
+<h2 id="text%20test">text <a href="http://google.com">test</a></h2>
 <h2 id="text"><strong>text</strong></h2>
 <h2 id="text-2"><em>text</em></h2>
 <h2 id="text-3"><s>text</s></h2>\n`,

--- a/src/index.js
+++ b/src/index.js
@@ -84,8 +84,10 @@ const treeToMarkdownBulletList = (tree, indent = 0) => tree.map(item => {
   const indentation = "  "
   let node = `${ repeat(indentation, indent) }*`
   if (item.heading.content) {
+    const contentWithoutAnchor
+          = item.heading.content.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
     node += " " +
-            `[${ item.heading.content }](#${ item.heading.anchor })\n`
+            `[${ contentWithoutAnchor }](#${ item.heading.anchor })\n`
   }
   else {
     node += "\n"


### PR DESCRIPTION
Header の途中にリンクが含まれていても TOC のアンカーを正しく設定できるようにしました。

input

```markdown
# [test](http://google.com)
## text [test](http://google.com)
## **text**
## *text*
## ~~text~~
```

output

```html
<ul class="markdownIt-TOC">
<li><a href="#test">test</a>
<ul>
<li>[text <a href="http://google.com">test</a>](#text%20test)</li>
<li><a href="#text"><strong>text</strong></a></li>
<li><a href="#text-2"><em>text</em></a></li>
<li><a href="#text-3"><s>text</s></a></li>
</ul>
</li>
</ul>
```

expected output

```html
<ul class="markdownIt-TOC">
<li><a href="#test">test</a>
<ul>
<li><a href="#text%20test">text test</a></li>
<li><a href="#text"><strong>text</strong></a></li>
<li><a href="#text-2"><em>text</em></a></li>
<li><a href="#text-3"><s>text</s></a></li>
</ul>
</li>
</ul>
```
